### PR TITLE
made the contact page reactive to small screen size

### DIFF
--- a/src/app/ContactSection/page.tsx
+++ b/src/app/ContactSection/page.tsx
@@ -14,8 +14,9 @@ const ContactSection = () => {
           <p className="text-center m-5 text-xl">
             Get in touch with us in case of any queries,suggestions or feedback.
           </p>
-          <div className="border-4 inline-block mx-80 my-5 bg-slate-100">
-            <div className="flex justify-center m-5">
+          {/* make it responsive */}
+          <div className="border-4 inline-block md:mx-80 my-5 bg-slate-100 justify-evenly w-auto md:w-auto lg:w-3/4  mt-8 lg:flex flex-wrap max-md:mt-16">  
+            <div className="md:flex md:shrink-0 justify-center items-center m-5">
               <div>
                 <form action="" className="w-96">
                   <label


### PR DESCRIPTION
Closes #90 : [Responsiveness] The contact form is not responsive

## Fixes Issue

This pull request addresses the issue of the contact form not being responsive on small screens. The form was previously overflowing, making it difficult to use on devices with smaller screen sizes. The few changes have been implemented to tailwind css of the "Contact Section" component to ensure a seamless user experience across all devices.

## Screenshots

<!-- Add all the screenshots which support your changes -->
<img width="584" alt="Screenshot 2024-05-26 at 11 37 02 PM" src="https://github.com/AbhiPatel10/openzone/assets/114846698/d7dbdb0c-c5f7-49a4-8225-bd475867e88b">
<img width="574" alt="Screenshot 2024-05-26 at 11 37 17 PM" src="https://github.com/AbhiPatel10/openzone/assets/114846698/ea4d264e-072d-4774-b690-b31a321ff417">
<img width="574" alt="Screenshot 2024-05-26 at 11 37 21 PM" src="https://github.com/AbhiPatel10/openzone/assets/114846698/656de098-fd3e-4d6e-8b51-d3685a1cf47a">

##Checklist:

- Verified no overflow issues
- Ensured compatibility with major browsers
- Tested on small screens (e.g., mobile devices)
 
 

